### PR TITLE
feat: enable multi-platform build for Rails Base Image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and Push Multi-Platform Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,18 +16,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Docker image
-        run: |
-          docker build \
-            --build-arg RUBY_VERSION=3.4.1 \
-            --build-arg RAILS_VERSION=8.0.1 \
-            --build-arg NODE_VERSION=22.13.0 \
-            -t $IMAGE_NAME:latest .
-      - name: Push Docker image
-        run: docker push $IMAGE_NAME:latest
+      - name: Build and Push Multi-Platform Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest
+          build-args: |-
+            RUBY_VERSION=3.4.1
+            RAILS_VERSION=8.0.1
+            NODE_VERSION=22.13.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
- Updated GitHub Actions workflow to support multi-platform builds using Docker Buildx.
- Added `linux/amd64` and `linux/arm64` as target platforms.
- Integrated `docker/setup-buildx-action` for multi-platform support.
- Modified build step to use `docker/build-push-action@v5`.
- Retained build arguments for `RUBY_VERSION`, `RAILS_VERSION`, and `NODE_VERSION`.
- Simplified image tagging with `latest` tag pushed to GitHub Container Registry.
