### PR TITLE
Update dependencies and add new gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,18 @@
 source "https://rubygems.org"
 
 # Core Rails dependencies
-gem "rails", "8.0.1"
-gem "puma", "6.5.0"
 gem "bootsnap", "1.18.4"
+gem "cssbundling-rails", "4.17.0"
+gem "irb", "1.15.1"
+gem "jsbundling-rails", "1.4.1"
+gem "net-imap", "0.5.6"
+gem "net-smtp", "0.5.1"
+gem "nokogiri", "1.18.3"
 gem "propshaft", "1.1.0"
+gem "puma", "6.6.0"
 gem "racc", "1.8.1"
+gem "rack", "3.1.10"
+gem "rails", "8.0.1"
 
 # Hotwire
 gem "turbo-rails", "2.0.11"
@@ -17,6 +24,7 @@ gem "amazing_print", "1.7.2"
 gem "bootstrap_form", "5.4"
 gem "meta-tags", "2.22.1"
 gem "faraday", "2.12.2"
+gem "rails_semantic_logger", "4.17.0"
 
 # GCP
 gem "cloudenvoy", "0.6.0"


### PR DESCRIPTION
- Updated `puma` to version `6.6.0`.
- Added new gems: `cssbundling-rails`, `irb`, `jsbundling-rails`,
  `net-imap`, `net-smtp`, `nokogiri`, `rack`, and
  `rails_semantic_logger`.
